### PR TITLE
Possible fix for some surveys not displaying as cyan when due within 30 days

### DIFF
--- a/resources/views/dashboard/test_status.blade.php
+++ b/resources/views/dashboard/test_status.blade.php
@@ -33,7 +33,7 @@
                   $test_date = new DateTime($td->test_date);
                   $days = $test_date->diff($today)->format('%a');
 
-                  if ($days < 355) {
+                  if ($days < 335) {
                   if ($td->test_date > date("Y-m-d")) {
                   echo "<div class=\"bg-primary\">" . $td->test_date . "</div>";
                   }


### PR DESCRIPTION
### Requirements
One-line change, should merge easily.

### Description of the Change
When looking at the survey status, I noticed that some surveys which are due in less than a month were not displaying in cyan as expected. 

In `views/dashboard/test_status.blade.php`, there is an if-elseif-else cond check which proceeds `<355, >=335 && < 365, >=365 && <395...`. This appears to be a typo since the first and second conditions are not mutually exclusive.
### Alternate Designs
N/A

### Why Should This Be In Core?
Bugfix is likely necessary to obtain the intended functionality.

### Benefits
Helps easily see which surveys are coming due.

### Possible Drawbacks
Needs to be tested.

### Applicable Issues
N/A, bug fixed immediately when issue discovered.
